### PR TITLE
Allow countdown clock to countdown to 0 instead of 1.

### DIFF
--- a/js/flipclock/flipclock.js
+++ b/js/flipclock/flipclock.js
@@ -527,7 +527,7 @@ var FlipClock;
 					t.factory.time.time++;
 				}
 				else {
-					if(t.factory.time.time === 0) {
+					if(t.factory.time.time <= 0) {
 						t.factory.stop();
 					}
 					


### PR DESCRIPTION
I didn't see any info on how to generate the minified version of the lib, so that hasn't been updated in this pull request.

I also made a small addition to ensure that the seconds input are coerced to an integer.
