### PR TITLE
Fixed 3 problems in styles and formatting

### DIFF
--- a/css/flipclock.css
+++ b/css/flipclock.css
@@ -85,6 +85,8 @@
 	width: 100%;
 	height: 100%;
 	list-style: none !important;
+	margin: 0 !important;
+	padding: 0 !important;
 }
 
 .flip-clock-wrapper ul li:first-child {


### PR DESCRIPTION
Fixed margin & padding override for ".flip-clock-wrapper ul"
- "!important" for margin
- added "padding: 0 !important;" to prevent override

Added "list-style: none !important;" for ".flip-clock-wrapper ul li"

Fixed numbers width changing bug in FF (bad font-size for ".flip-clock-wrapper ul li a div div.inn")
![flipclockffbug](https://f.cloud.github.com/assets/3281210/690428/eff91b08-daed-11e2-8ff0-56bded08aa0f.jpg)

Fixed proper formatting (tabbing)
