### PR TITLE
Fixed a "twitch" when a CSS transition happened and added -ms-box-sizing...

### DIFF
--- a/css/flipclock.css
+++ b/css/flipclock.css
@@ -4,8 +4,14 @@
     padding: 0;
     -webkit-box-sizing: border-box;
     -moz-box-sizing: border-box;
+    -ms-box-sizing: border-box;
     -o-box-sizing: border-box;
     box-sizing: border-box;
+    -webkit-backface-visibility: hidden;
+    -moz-backface-visibility: hidden;
+    -ms-backface-visibility: hidden;
+    -o-backface-visibility: hidden;
+    backface-visibility: hidden;
 }
 
 .flip-clock-wrapper a {


### PR DESCRIPTION
Twitch occurred on Chrome where, whenever a transition occurred, the text would all twitch. Adding backface-visibility fixes this.

I also added in a -ms-box-sizing since it was missing.
