### PR TITLE
Fixed jagged edges in Firefox

### DIFF
--- a/css/flipclock.css
+++ b/css/flipclock.css
@@ -107,6 +107,7 @@
   width: 100%;
   height: 50%;
   font-size: 80px;
+  outline: 1px solid transparent;
   overflow: hidden; }
 
 .flip-clock-wrapper ul li a div .shadow {


### PR DESCRIPTION
Adding "outline: 1px solid transparent" to ".flip-clock-wrapper ul li a div" fixes the jagged edges problem in Firefox
