### PR TITLE
issue with not checking array prototype changes

### DIFF
--- a/js/flipclock/flipclock.js
+++ b/js/flipclock/flipclock.js
@@ -398,7 +398,9 @@ var FlipClock;
 			this.timer.stop(callback);
 			
 			for(var x in this.lists) {
-				this.lists[x].stop();
+				if (this.lists.hasOwnProperty(x)) {
+					this.lists[x].stop();
+				}
 			}	
 		},
 		


### PR DESCRIPTION
fix an issue where if array had its prototype altered the for would try to call stop on things it shouldnt
