### PR TITLE
IE 7 fix for counter display

### DIFF
--- a/js/flipclock/flipclock.js
+++ b/js/flipclock/flipclock.js
@@ -923,7 +923,7 @@ var FlipClock;
 				}
 				
 				for(var x = 0; x < value.length; x++) {
-					data.push(value[x]);
+					data.push(value.charAt(x));
 				}				
 			});
 			


### PR DESCRIPTION
Fixed counter display issue for IE7. Only for source flipclock.js
