### PR TITLE
Reseting line-height, so the plugin does not get affected by other frameworks like bootstrap

### DIFF
--- a/src/flipclock/css/flipclock.scss
+++ b/src/flipclock/css/flipclock.scss
@@ -5,6 +5,7 @@
 .flip-clock-wrapper * {
     margin: 0;
     padding: 0;
+    line-height: normal;
     @include box-sizing(border-box);
 }
 


### PR DESCRIPTION
The current plugin seems to be affected by the line-height:20px from bootstrap. Setting this line-height to normal in the resetting stage should solve this problem.  
