### PR TITLE
Fixed issue that allows it to work with Boostrap library

### DIFF
--- a/src/flipclock/css/flipclock.css
+++ b/src/flipclock/css/flipclock.css
@@ -84,6 +84,7 @@
   top: 0;
   width: 100%;
   height: 100%;
+  line-height: 87px;
   text-decoration: none !important;
 }
 

--- a/src/flipclock/css/flipclock.scss
+++ b/src/flipclock/css/flipclock.scss
@@ -84,6 +84,7 @@
     top: 0;
     width: 100%;
     height: 100%;
+	line-height: 87px;
 }
 
 .flip-clock-wrapper ul li:first-child {


### PR DESCRIPTION
Hi There :)

I was using the plugin with Bootstrap and was causing an issue whereby the line height for li's was set by Bootstrap, rather than the flipclock.

![image](https://f.cloud.github.com/assets/6059732/2263562/6240bb48-9e67-11e3-85f8-c9304368e40c.png)

Added a line which defines the li as having the line height, overwriting any changes from bootstrap.
