### PR TITLE
fix #84 – set asset paths in examples to reference files in '../src/' directory

### DIFF
--- a/examples/base.html
+++ b/examples/base.html
@@ -1,17 +1,17 @@
 <html>
 	<head>
-		<link rel="stylesheet" href="../css/flipclock.css">
+		<link rel="stylesheet" href="../src/flipclock/css/flipclock.css">
 
 		<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
 
-		<script src="../js/flipclock/libs/base.js"></script>
-		<script src="../js/flipclock/flipclock.js"></script>
-		<script src="../js/flipclock/faces/counter.js"></script>
-		<script src="../js/flipclock/faces/hourlycounter.js"></script>
-		<script src="../js/flipclock/faces/dailycounter.js"></script>
-		<script src="../js/flipclock/faces/minutecounter.js"></script>
-		<script src="../js/flipclock/faces/twentyfourhourclock.js"></script>
-		<script src="../js/flipclock/faces/twelvehourclock.js"></script>
+		<script src="../src/flipclock/js/libs/base.js"></script>
+		<script src="../src/flipclock/js/libs/flipclock.js"></script>
+		<script src="../src/flipclock/js/faces/counter.js"></script>
+		<script src="../src/flipclock/js/faces/hourlycounter.js"></script>
+		<script src="../src/flipclock/js/faces/dailycounter.js"></script>
+		<script src="../src/flipclock/js/faces/minutecounter.js"></script>
+		<script src="../src/flipclock/js/faces/twentyfourhourclock.js"></script>
+		<script src="../src/flipclock/js/faces/twelvehourclock.js"></script>
 		
 	</head>
 	<body>

--- a/examples/countdown-from-new-years-without-seconds.html
+++ b/examples/countdown-from-new-years-without-seconds.html
@@ -1,12 +1,12 @@
 <html>
 	<head>
-		<link rel="stylesheet" href="../css/flipclock.css">
+		<link rel="stylesheet" href="../src/flipclock/css/flipclock.css">
 
 		<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
 
-		<script src="../js/flipclock/libs/base.js"></script>
-		<script src="../js/flipclock/flipclock.js"></script>
-		<script src="../js/flipclock/faces/dailycounter.js"></script>		
+		<script src="../src/flipclock/js/libs/base.js"></script>
+		<script src="../src/flipclock/js/libs/flipclock.js"></script>
+		<script src="../src/flipclock/js/faces/dailycounter.js"></script>		
 	</head>
 	<body>
 		<div class="clock" style="margin:2em;"></div>

--- a/examples/countdown-from-new-years.html
+++ b/examples/countdown-from-new-years.html
@@ -1,12 +1,12 @@
 <html>
 	<head>
-		<link rel="stylesheet" href="../css/flipclock.css">
+		<link rel="stylesheet" href="../src/flipclock/css/flipclock.css">
 
 		<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
 
-		<script src="../js/flipclock/libs/base.js"></script>
-		<script src="../js/flipclock/flipclock.js"></script>
-		<script src="../js/flipclock/faces/dailycounter.js"></script>		
+		<script src="../src/flipclock/js/libs/base.js"></script>
+		<script src="../src/flipclock/js/libs/flipclock.js"></script>
+		<script src="../src/flipclock/js/faces/dailycounter.js"></script>		
 	</head>
 	<body>
 		<div class="clock" style="margin:2em;"></div>

--- a/examples/countdown-start-callback.html
+++ b/examples/countdown-start-callback.html
@@ -1,13 +1,13 @@
 <html>
 	<head>
-		<link rel="stylesheet" href="../css/flipclock.css">
+		<link rel="stylesheet" href="../src/flipclock/css/flipclock.css">
 
 		<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
 
-		<script src="../js/flipclock/libs/base.js"></script>
-		<script src="../js/flipclock/flipclock.js"></script>
-		<script src="../js/flipclock/faces/hourlycounter.js"></script>
-		<script src="../js/flipclock/faces/minutecounter.js"></script>
+		<script src="../src/flipclock/js/libs/base.js"></script>
+		<script src="../src/flipclock/js/libs/flipclock.js"></script>
+		<script src="../src/flipclock/js/faces/hourlycounter.js"></script>
+		<script src="../src/flipclock/js/faces/minutecounter.js"></script>
 		
 	</head>
 	<body>

--- a/examples/countdown-stop-callback.html
+++ b/examples/countdown-stop-callback.html
@@ -1,13 +1,13 @@
 <html>
 	<head>
-		<link rel="stylesheet" href="../css/flipclock.css">
+		<link rel="stylesheet" href="../src/flipclock/css/flipclock.css">
 
 		<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
 
-		<script src="../js/flipclock/libs/base.js"></script>
-		<script src="../js/flipclock/flipclock.js"></script>
-		<script src="../js/flipclock/faces/hourlycounter.js"></script>
-		<script src="../js/flipclock/faces/minutecounter.js"></script>
+		<script src="../src/flipclock/js/libs/base.js"></script>
+		<script src="../src/flipclock/js/libs/flipclock.js"></script>
+		<script src="../src/flipclock/js/faces/hourlycounter.js"></script>
+		<script src="../src/flipclock/js/faces/minutecounter.js"></script>
 		
 	</head>
 	<body>

--- a/examples/countdown-to-new-years-without-seconds.html
+++ b/examples/countdown-to-new-years-without-seconds.html
@@ -1,12 +1,12 @@
 <html>
 	<head>
-		<link rel="stylesheet" href="../css/flipclock.css">
+		<link rel="stylesheet" href="../src/flipclock/css/flipclock.css">
 
 		<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
 
-		<script src="../js/flipclock/libs/base.js"></script>
-		<script src="../js/flipclock/flipclock.js"></script>
-		<script src="../js/flipclock/faces/dailycounter.js"></script>		
+		<script src="../src/flipclock/js/libs/base.js"></script>
+		<script src="../src/flipclock/js/libs/flipclock.js"></script>
+		<script src="../src/flipclock/js/faces/dailycounter.js"></script>		
 	</head>
 	<body>
 		<div class="clock" style="margin:2em;"></div>

--- a/examples/countdown-to-new-years.html
+++ b/examples/countdown-to-new-years.html
@@ -1,12 +1,12 @@
 <html>
 	<head>
-		<link rel="stylesheet" href="../css/flipclock.css">
+		<link rel="stylesheet" href="../src/flipclock/css/flipclock.css">
 
 		<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
 
-		<script src="../js/flipclock/libs/base.js"></script>
-		<script src="../js/flipclock/flipclock.js"></script>
-		<script src="../js/flipclock/faces/dailycounter.js"></script>		
+		<script src="../src/flipclock/js/libs/base.js"></script>
+		<script src="../src/flipclock/js/libs/flipclock.js"></script>
+		<script src="../src/flipclock/js/faces/dailycounter.js"></script>		
 	</head>
 	<body>
 		<div class="clock" style="margin:2em;"></div>

--- a/examples/localization.html
+++ b/examples/localization.html
@@ -1,13 +1,13 @@
 <html>
 	<head>
-		<link rel="stylesheet" href="../css/flipclock.css">
+		<link rel="stylesheet" href="../src/flipclock/css/flipclock.css">
 
 		<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
 
-		<script src="../js/flipclock/libs/base.js"></script>
-		<script src="../js/flipclock/flipclock.js"></script>
-		<script src="../js/flipclock/lang/es-es.js"></script>
-		<script src="../js/flipclock/faces/dailycounter.js"></script>
+		<script src="../src/flipclock/js/libs/base.js"></script>
+		<script src="../src/flipclock/js/libs/flipclock.js"></script>
+		<script src="../src/flipclock/js/lang/es-es.js"></script>
+		<script src="../src/flipclock/js/faces/dailycounter.js"></script>
 		
 	</head>
 	<body>

--- a/examples/simple-counter.html
+++ b/examples/simple-counter.html
@@ -1,12 +1,12 @@
 <html>
 	<head>
-		<link rel="stylesheet" href="../css/flipclock.css">
+		<link rel="stylesheet" href="../src/flipclock/css/flipclock.css">
 		
 		<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
 
-		<script src="../js/flipclock/libs/base.js"></script>
-		<script src="../js/flipclock/flipclock.js"></script>
-		<script src="../js/flipclock/faces/counter.js"></script>		
+		<script src="../src/flipclock/js/libs/base.js"></script>
+		<script src="../src/flipclock/js/libs/flipclock.js"></script>
+		<script src="../src/flipclock/js/faces/counter.js"></script>		
 	</head>
 	<body>
 		<div class="clock" style="margin:2em;"></div>

--- a/examples/twelve-hour-clock.html
+++ b/examples/twelve-hour-clock.html
@@ -1,17 +1,17 @@
 <html>
 	<head>
-		<link rel="stylesheet" href="../css/flipclock.css">
+		<link rel="stylesheet" href="../src/flipclock/css/flipclock.css">
 
 		<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
 
-		<script src="../js/flipclock/libs/base.js"></script>
-		<script src="../js/flipclock/flipclock.js"></script>
-		<script src="../js/flipclock/faces/counter.js"></script>
-		<script src="../js/flipclock/faces/hourlycounter.js"></script>
-		<script src="../js/flipclock/faces/dailycounter.js"></script>
-		<script src="../js/flipclock/faces/minutecounter.js"></script>
-		<script src="../js/flipclock/faces/twentyfourhourclock.js"></script>
-		<script src="../js/flipclock/faces/twelvehourclock.js"></script>
+		<script src="../src/flipclock/js/libs/base.js"></script>
+		<script src="../src/flipclock/js/libs/flipclock.js"></script>
+		<script src="../src/flipclock/js/faces/counter.js"></script>
+		<script src="../src/flipclock/js/faces/hourlycounter.js"></script>
+		<script src="../src/flipclock/js/faces/dailycounter.js"></script>
+		<script src="../src/flipclock/js/faces/minutecounter.js"></script>
+		<script src="../src/flipclock/js/faces/twentyfourhourclock.js"></script>
+		<script src="../src/flipclock/js/faces/twelvehourclock.js"></script>
 		
 	</head>
 	<body>

--- a/examples/twenty-four-hour-clock.html
+++ b/examples/twenty-four-hour-clock.html
@@ -1,17 +1,17 @@
 <html>
 	<head>
-		<link rel="stylesheet" href="../css/flipclock.css">
+		<link rel="stylesheet" href="../src/flipclock/css/flipclock.css">
 
 		<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
 
-		<script src="../js/flipclock/libs/base.js"></script>
-		<script src="../js/flipclock/flipclock.js"></script>
-		<script src="../js/flipclock/faces/counter.js"></script>
-		<script src="../js/flipclock/faces/hourlycounter.js"></script>
-		<script src="../js/flipclock/faces/dailycounter.js"></script>
-		<script src="../js/flipclock/faces/minutecounter.js"></script>
-		<script src="../js/flipclock/faces/twentyfourhourclock.js"></script>
-		<script src="../js/flipclock/faces/twelvehourclock.js"></script>
+		<script src="../src/flipclock/js/libs/base.js"></script>
+		<script src="../src/flipclock/js/libs/flipclock.js"></script>
+		<script src="../src/flipclock/js/faces/counter.js"></script>
+		<script src="../src/flipclock/js/faces/hourlycounter.js"></script>
+		<script src="../src/flipclock/js/faces/dailycounter.js"></script>
+		<script src="../src/flipclock/js/faces/minutecounter.js"></script>
+		<script src="../src/flipclock/js/faces/twentyfourhourclock.js"></script>
+		<script src="../src/flipclock/js/faces/twelvehourclock.js"></script>
 		
 	</head>
 	<body>


### PR DESCRIPTION
Not sure if you wanted the compiled or source files referenced, but given the current structure of the examples, I referenced the source.
