### PR TITLE
Remove console.log from flip callback

### DIFF
--- a/src/flipclock/js/libs/face.js
+++ b/src/flipclock/js/libs/face.js
@@ -221,8 +221,6 @@
 			}
 			*/
 
-			console.log(t.lists);
-
 			$.each(time, function(i, digit) {
 				var list = t.lists[i];
 


### PR DESCRIPTION
This log is taking over my console. Can you merge this so we aren't dealing with development code?
