### PR TITLE
Fix Spanish

### DIFF
--- a/compiled/flipclock.js
+++ b/compiled/flipclock.js
@@ -2490,7 +2490,7 @@ var FlipClock;
 		
 		'years'   : 'A&#241;os',
 		'months'  : 'Meses',
-		'days'    : 'D&#205;as',
+		'days'    : 'D&#237;as',
 		'hours'   : 'Horas',
 		'minutes' : 'Minutos',
 		'seconds' : 'Segundo'	


### PR DESCRIPTION
Small adjust line 2493, appeared in Spanish "DÍas" = "D&#205;as" with Í capital letter, but the right is  "Días" = "D&#237;as" with í lowercase
