### PR TITLE
shadows don't have a border radius

### DIFF
--- a/src/flipclock/css/flipclock.scss
+++ b/src/flipclock/css/flipclock.scss
@@ -7,7 +7,7 @@
     padding: 0;
     line-height: normal;
     @include box-sizing(border-box);
-}
+}s
 
 .flip-clock-wrapper a {
     cursor: pointer;
@@ -113,6 +113,7 @@
     width: 100%;
     height: 100%;
     z-index: 2;
+    border-radius: 6px;
 }
 
 .flip-clock-wrapper ul li a div.up {


### PR DESCRIPTION
This becomes visible when you scale the clock, and its on a white background.
