### PR TITLE
Fixed constructor bug passing "factory"

### DIFF
--- a/src/flipclock/js/libs/face.js
+++ b/src/flipclock/js/libs/face.js
@@ -135,7 +135,7 @@
 
 		reset: function() {
 			this.factory.time = new FlipClock.Time(
-				this.factor, 
+				this.factory, 
 				this.factory.original ? Math.round(this.factory.original) : 0,
 				{
 					minimumDigits: this.factory.minimumDigits


### PR DESCRIPTION
Updated face.js, the "factory" was not being passed into the constructor, instead a typo was "factor".
