### PR TITLE
Add support for weekly countdown

### DIFF
--- a/src/flipclock/js/faces/weeklycounter.js
+++ b/src/flipclock/js/faces/weeklycounter.js
@@ -1,0 +1,79 @@
+(function($) {
+
+	/**
+	 * Weekly Counter Clock Face
+	 *
+	 * This class will generate a weekly counter for FlipClock.js. A
+	 * weekly counter will track weeks, days, hours, minutes, and seconds. If
+	 * the number of available digits is exceeded in the count, a new
+	 * digit will be created.
+	 *
+	 * @param  object  The parent FlipClock.Factory object
+	 * @param  object  An object of properties to override the default
+	 */
+
+	FlipClock.WeeklyCounterFace = FlipClock.Face.extend({
+
+		showSeconds: true,
+
+		/**
+		 * Constructor
+		 *
+		 * @param  object  The parent FlipClock.Factory object
+		 * @param  object  An object of properties to override the default
+		 */
+
+		constructor: function(factory, options) {
+			this.base(factory, options);
+		},
+
+		/**
+		 * Build the clock face
+		 */
+
+		build: function(time) {
+			var t = this;
+			var children = this.factory.$el.find('ul');
+			var offset = 0;
+
+			time = time ? time : this.factory.time.getWeekCounter(this.showSeconds);
+
+			if(time.length > children.length) {
+				$.each(time, function(i, digit) {
+					t.createList(digit);
+				});
+			}
+
+			if(this.showSeconds) {
+				$(this.createDivider('Seconds')).insertBefore(this.lists[this.lists.length - 2].$el);
+			}
+			else
+			{
+				offset = 2;
+			}
+
+			$(this.createDivider('Minutes')).insertBefore(this.lists[this.lists.length - 4 + offset].$el);
+			$(this.createDivider('Hours')).insertBefore(this.lists[this.lists.length - 6 + offset].$el);
+			$(this.createDivider('Days')).insertBefore(this.lists[this.lists.length - 8 + offset].$el);
+			$(this.createDivider('Weeks', true)).insertBefore(this.lists[0].$el);
+
+
+			this.base();
+		},
+
+		/**
+		 * Flip the clock face
+		 */
+
+		flip: function(time, doNotAddPlayClass) {
+			if(!time) {
+				time = this.factory.time.getWeekCounter(this.showSeconds);
+			}
+
+			this.autoIncrement();
+
+			this.base(time, doNotAddPlayClass);
+		}
+
+	});
+}(jQuery));

--- a/src/flipclock/js/libs/time.js
+++ b/src/flipclock/js/libs/time.js
@@ -177,6 +177,27 @@
 		},
 
 		/**
+		 * Gets a digitized weekly counter
+		 *
+		 * @return  object  Returns a digitized object
+		 */
+
+		getWeekCounter: function(includeSeconds) {
+			var digits = [
+				this.getWeeks(),
+				(this.getWeeks() + 1) * 7 - this.getDays(),
+				this.getHours(true),
+				this.getMinutes(true)
+			];
+
+			if(includeSeconds) {
+				digits.push(this.getSeconds(true));
+			}
+
+			return this.digitize(digits);
+		},
+
+		/**
 		 * Gets number of days
 		 *
 		 * @param   bool  Should perform a modulus? If not sent, then no.


### PR DESCRIPTION
Fixes #198

The following code should show this off, assuming an html element with
class="clock" attribute set.

```

  $(document).ready(function () {
    // Grab the current date
    var currentDate = new Date();
    var eventStart = new Date("Nov 30, 2015");

    // Calculate the difference in seconds between the future and current date
    var diff = eventStart.getTime() / 1000 - currentDate.getTime() / 1000;

    // Instantiate a coutdown FlipClock
    clock = $('.clock').FlipClock(diff, {
      clockFace: 'WeeklyCounter',
      // clockFace: 'DailyCounter',
      countdown: true,
    });
  });

```
