### PR TITLE
setCountdown to true before setting time

### DIFF
--- a/examples/daily-counter-countdown.html
+++ b/examples/daily-counter-countdown.html
@@ -26,8 +26,8 @@
 		        }
 		    });
 				    
-		    clock.setTime(220880);
 		    clock.setCountdown(true);
+		    clock.setTime(220880);
 		    clock.start();
 
 		});


### PR DESCRIPTION
this prevents executing the increment before it actually knows that is a countdown

if you see this example you will se the seconds counter first going up by 1 and then the countdown begins.

setting the clock to be countdown before the time fixes the demo