### PR TITLE
Fixed 'Segundo' to 'Segundos'

### DIFF
--- a/src/flipclock/js/lang/es-es.js
+++ b/src/flipclock/js/lang/es-es.js
@@ -1,27 +1,27 @@
 (function($) {
-		
-	/**
-	 * FlipClock Spanish Language Pack
-	 *
-	 * This class will used to translate tokens into the Spanish language.
-	 *	
-	 */
-	 
-	FlipClock.Lang.Spanish = {
-		
-		'years'   : 'A&#241;os',
-		'months'  : 'Meses',
-		'days'    : 'D&#205;as',
-		'hours'   : 'Horas',
-		'minutes' : 'Minutos',
-		'seconds' : 'Segundo'	
 
-	};
-	
-	/* Create various aliases for convenience */
+  /**
+   * FlipClock Spanish Language Pack
+   *
+   * This class will used to translate tokens into the Spanish language.
+   *
+   */
 
-	FlipClock.Lang['es']      = FlipClock.Lang.Spanish;
-	FlipClock.Lang['es-es']   = FlipClock.Lang.Spanish;
-	FlipClock.Lang['spanish'] = FlipClock.Lang.Spanish;
+  FlipClock.Lang.Spanish = {
+    
+    'years'   : 'A&#241;os',
+    'months'  : 'Meses',
+    'days'    : 'D&#205;as',
+    'hours'   : 'Horas',
+    'minutes' : 'Minutos',
+    'seconds' : 'Segundos'
+
+  };
+
+  /* Create various aliases for convenience */
+
+  FlipClock.Lang['es']      = FlipClock.Lang.Spanish;
+  FlipClock.Lang['es-es']   = FlipClock.Lang.Spanish;
+  FlipClock.Lang['spanish'] = FlipClock.Lang.Spanish;
 
 }(jQuery));


### PR DESCRIPTION
Fixed translation of 'seconds' to 'Segundos', from 'Segundo'. Also cleaned some withespace.