### PR TITLE
Add `main` field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "email": "support@objectivehtml.com",
   "author": "Objective HTML, LLC <support@objectivehtml.com>",
   "license": "MIT",
+  "main": "compiled/flipclock.js",
   "devDependencies": {
     "grunt": "~0.4.2",
     "grunt-contrib-concat": "~0.3.0",

--- a/src/flipclock/js/libs/core.js
+++ b/src/flipclock/js/libs/core.js
@@ -7,7 +7,7 @@ var FlipClock;
  *
  * @author     Justin Kimbrell
  * @copyright  2013 - Objective HTML, LLC
- * @licesnse   http://www.opensource.org/licenses/mit-license.php
+ * @license   http://www.opensource.org/licenses/mit-license.php
  */
 	
 (function($) {


### PR DESCRIPTION
Adding a `main` field so that npm knows what file to include when the package is required.