### PR TITLE
Proposed improvements to flipclock.scss

### DIFF
--- a/src/flipclock/css/flipclock.scss
+++ b/src/flipclock/css/flipclock.scss
@@ -6,7 +6,7 @@
     margin: 0;
     padding: 0;
     line-height: normal;
-    @include box-sizing(border-box);
+    box-sizing: border-box;
 }
 
 .flip-clock-wrapper a {
@@ -40,41 +40,37 @@
 /* Main */
 
 .flip-clock-wrapper {
-    min-height: 100%;
+    white-space: nowrap;
     font: normal 11px "Helvetica Neue", Helvetica, sans-serif;
     -webkit-user-select: none;
 }
 
 .flip-clock-meridium {
-	background: none;
-	box-shadow: 0 0 0 !important;
-	font-size: 36px !important;
-	color: rgb(49, 51, 51);
-	bottom: 10px;
+    background: none;
+    box-shadow: 0 0 0 !important;
+    font-size: 2em;
+    color: rgb(49, 51, 51);
 }
-
 
 .flip-clock-wrapper {
     text-align: center;
     position: relative;
-    width: 100%;
-    margin: 1em;
+    margin: 2em 0 1em;
 }
 
 /* Skeleton */
 
 .flip-clock-wrapper ul {
     position: relative;
-    float: left;
-    margin: 5px;
-    width: 60px;
-    height: 90px;
-    font-size: 80px;
+    display: inline-block;
+    margin: 0.20em;
+    width: 2.9em;
+    height: 4.1em;
+    font-size: 1.9em;
     font-weight: bold;
-    line-height: 87px;
-    border-radius: 6px_prefixed
-    ;
-    box-shadow: 0 2px 5px rgba(0, 0, 0, .7);
+    line-height: 4.3em;
+    border-radius: 0.5em;
+    box-shadow: 0 0.1em 0.25em rgba(0, 0, 0, 0.7);
 }
 
 .flip-clock-wrapper ul li {
@@ -84,7 +80,7 @@
     top: 0;
     width: 100%;
     height: 100%;
-	line-height: 87px;
+    line-height: 4.3em;
 }
 
 .flip-clock-wrapper ul li:first-child {
@@ -94,7 +90,7 @@
 .flip-clock-wrapper ul li a {
     display: block;
     height: 100%;
-    @include perspective(200px);
+    @include perspective(12em);
     margin: 0 !important;
     overflow: visible !important;
 }
@@ -104,8 +100,9 @@
     position: absolute;
     left: 0;
     width: 100%;
-    height: 50%;
+    height: 50.05%;
     overflow: hidden;
+    font-size: 1.9em;
 }
 
 .flip-clock-wrapper ul li a div .shadow {
@@ -122,12 +119,12 @@
 
 .flip-clock-wrapper ul li a div.up:after {
   content: "";
-  position:absolute;
-  top:44px;
-  left:0;
+  position: absolute;
+  top: 98%;
+  left: 0;
   z-index: 5;
   width: 100%;
-  height: 3px;
+  height: 4%;
   background-color: #000;
   background-color: rgba(0,0,0,.4);
 }
@@ -135,6 +132,8 @@
 .flip-clock-wrapper ul li a div.down {
     @include transform-origin(50% 0);
     bottom: 0;
+    border-bottom-left-radius: 0.12em;
+    border-bottom-right-radius: 0.12em;
 }
 
 .flip-clock-wrapper ul li a div div.inn {
@@ -144,11 +143,11 @@
     width: 100%;
     height: 200%;
     color: #ccc;
-    text-shadow: 0 1px 2px #000;
+    text-shadow: 0 0.02em 0.05em #000;
     text-align: center;
     background-color: #333;
-    border-radius: 6px;
-    font-size: 70px;
+    border-radius: 0.08em;
+    font-size: 1.8em;
 }
 
 .flip-clock-wrapper ul li a div.up div.inn {
@@ -172,42 +171,43 @@
 }
 
 .flip-clock-divider {
-	float: left;
-	display: inline-block;
-	position: relative;
-	width: 20px;
-	height: 100px;
+    display: inline-block;
+    position: relative;
+    width: 1.7em;
+    height: 9em;
 }
 
 .flip-clock-divider:first-child { width: 0; }
 
 .flip-clock-dot {
-	display: block;
-	background: rgb(50, 52, 52);
-	width: 10px;
-	height: 10px;
-	position: absolute;
-	border-radius: 50%;
-	box-shadow: 0 0 5px rgba(0, 0, 0, .5);
+    display: block;
+    background: rgb(50, 52, 52);
+    width: 0.9em;
+    height: 0.9em;
+    position: absolute;
+    border-radius: 50%;
+    left: 0.45em;
+    box-shadow: 0 0 0.5em rgba(0, 0, 0, 0.5);
 }
 
 .flip-clock-divider .flip-clock-label {
-	position: absolute;
-	top: -1.5em;
-	right: -86px;
-	color: black;
-	text-shadow: none;
+    position: absolute;
+    top: -1.5em;
+    right: -7.5em;
+    font-size: 100%;
+    color: black;
+    text-shadow: none;
 }
 
-.flip-clock-divider.minutes .flip-clock-label { right: -88px; }
-.flip-clock-divider.seconds .flip-clock-label { right: -91px; }
+.flip-clock-divider.minutes .flip-clock-label { right: -8.0em; }
+.flip-clock-divider.seconds .flip-clock-label { right: -8.2em; }
 
 .flip-clock-dot.top {
-	top: 30px;
+    top: 2.7em;
 }
 
 .flip-clock-dot.bottom {
-	bottom: 30px;
+    bottom: 2.7em;
 }
 
 @include keyframes(asd) {
@@ -272,6 +272,7 @@
     background: -ms-linear-gradient(top, rgba(0, 0, 0, .1) 0%, rgba(0, 0, 0, 1) 100%);
     background: linear-gradient(to bottom, rgba(0, 0, 0, .1) 0%, rgba(0, 0, 0, 1) 100%);
     @include animation(hide .5s .3s linear both);
+    border-radius: 0.08em 0.08em 0 0;
 }
 
 /*DOWN*/
@@ -284,6 +285,7 @@
     background: -ms-linear-gradient(top, rgba(0, 0, 0, 1) 0%, rgba(0, 0, 0, .1) 100%);
     background: linear-gradient(to bottom, rgba(0, 0, 0, 1) 0%, rgba(0, 0, 0, .1) 100%);
     @include animation(show .5s linear both);
+    border-radius: 0 0 0.08em 0.08em;
 }
 
 .flip-clock-wrapper ul.play li.flip-clock-active .down .shadow {
@@ -294,6 +296,7 @@
     background: -ms-linear-gradient(top, rgba(0, 0, 0, 1) 0%, rgba(0, 0, 0, .1) 100%);
     background: linear-gradient(to bottom, rgba(0, 0, 0, 1) 0%, rgba(0, 0, 0, .1) 100%);
     @include animation(hide .5s .3s linear both);
+    border-radius: 0.08em 0.08em 0 0;
 }
 
 @include keyframes(show) {


### PR DESCRIPTION
These changes make the numbers and meridian dividers display as inline-blocks so the entire clock can be centered horizontally.
Pixel units converted to percentages and ems so the entire clock can scale proportionally just by changing the font size of the wrapper.
Removed reference to deprecated Bourbon box-sizing mixin.
Fixed issue where flip shadows didn't have border radii and therefore projected a little bit of black into the corners of the numbers.
Please review!
