### PR TITLE
Update flipclock.css

### DIFF
--- a/compiled/flipclock.css
+++ b/compiled/flipclock.css
@@ -65,6 +65,7 @@
 
 /* Skeleton */
 .flip-clock-wrapper ul {
+  overflow: hidden;
   position: relative;
   float: left;
   margin: 5px;


### PR DESCRIPTION
Not having property "overflow" causes some bugs in Chrome 47.0.2526.111
![23-01-2016 005728](https://cloud.githubusercontent.com/assets/15844816/12524202/7abeae4e-c16c-11e5-86ab-6791d6d0f710.png)