### PR TITLE
Fix: EnglishAlphaFace fails to init because of missing default options

### DIFF
--- a/src/flipclock/js/libs/EnglishAlphaList.js
+++ b/src/flipclock/js/libs/EnglishAlphaList.js
@@ -26,6 +26,18 @@
 		options: {
 
 			/**
+			 * The CSS classes
+			 */
+
+			classes: {
+				active: 'flip-clock-active',
+				before: 'flip-clock-before',
+				flip: 'flip',
+				play: 'play'
+			},
+
+
+			/**
 			 * Tells the list to use capital letters if true
 			 */		
 			


### PR DESCRIPTION
The "english-alphabetical-clock.html" example is broken. There is a javascript error that is caused by EnglishAlphaList.js not having (or inheriting) the "classes" options array from List.js

This fix adds the required "classes" options to EnglishAlphaList.js so that the EnglishAlphaFace no longer results in a runtime error.