### PR TITLE
Properly remove animation class when timer is stopped

### DIFF
--- a/src/flipclock/js/libs/factory.js
+++ b/src/flipclock/js/libs/factory.js
@@ -169,7 +169,6 @@
 				options = {};
 			}
 
-			this.lists = [];
 			this.running = false;
 			this.base(options);	
 
@@ -316,9 +315,9 @@
 			this.face.stop();
 			this.timer.stop(callback);
 			
-			for(var x in this.lists) {
-				if (this.lists.hasOwnProperty(x)) {
-					this.lists[x].stop();
+			for(var x in this.face.lists) {
+				if (this.face.lists.hasOwnProperty(x)) {
+					this.face.lists[x].stop();
 				}
 			}	
 		},


### PR DESCRIPTION
The `play` class is left behind if timer is startet and then stopped. If the time would be changed with `setTime()` it will trigger the flip animation even when `flip(true)` is used.
This change removes the `play` class from the lists when the timer is stopped.