### PR TITLE
Removed conflicting CSS styles

### DIFF
--- a/src/scss/flipclock.scss
+++ b/src/scss/flipclock.scss
@@ -14,9 +14,7 @@
     -webkit-user-select: none;
     text-align: center;
     position: relative;
-    width: 100%;
-    display: inline-flex;
-    font-size: 1vw;
+    display: flex;
     font-family: "Helvetica Neue", Helvetica, sans-serif;
     box-sizing: border-box;
     align-items: flex-end;


### PR DESCRIPTION
Removed conflicting CSS styles that prevent proper custom styling and scaling of the outer flipclock element.