### PR TITLE
Add responsive scaling

### DIFF
--- a/compiled/flipclock.js
+++ b/compiled/flipclock.js
@@ -637,6 +637,12 @@ var FlipClock;
 		 */	
 		 
 		countdown: false,
+
+		/**
+		 * Scale the clock responsively. This value is the scale preffered on a screen 1920*1080. -1 to disable
+		 */
+
+		responsiveScale: -1,
 		 
 		/**
 		 * The name of the default clock face class to use if the defined
@@ -746,6 +752,8 @@ var FlipClock;
 			this.loadLanguage(this.language);
 			
 			this.loadClockFace(this.clockFace, options);
+
+			this.setResponsiveScale();
 
 			if(this.autoStart) {
 				this.start();
@@ -929,6 +937,18 @@ var FlipClock;
 		 */
 		flip: function(doNotAddPlayClass) {	
 			this.face.flip(false, doNotAddPlayClass);
+		},
+
+		/**
+		 * Sets the wrappers scaling responsively
+		 */
+		setResponsiveScale: function() {
+			if (this.responsiveScale != -1) {
+				var c = document.getElementsByClassName(this.classes.wrapper);
+				var perpx = this.responsiveScale / 1920;
+				var s = perpx * window.screen.width;
+				c[0].style.transform = "scale(" + s + ")";
+			}
 		}
 		
 	});

--- a/examples/responsive-scaling.html
+++ b/examples/responsive-scaling.html
@@ -1,0 +1,26 @@
+<html>
+	<head>
+		<link rel="stylesheet" href="../compiled/flipclock.css">
+
+		<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
+
+		<script src="../compiled/flipclock.js"></script>		
+	</head>
+	<body>
+	<div class="clock" style="margin:2em;"></div>
+	<div class="message"></div>
+
+	<script type="text/javascript">
+		var clock;
+		
+		$(document).ready(function() {
+			
+			clock = $('.clock').FlipClock({
+                clockFace: 'MinuteCounter',
+                responsiveScaling: 3
+		    });
+		});
+	</script>
+	
+	</body>
+</html>

--- a/examples/responsive-scaling.html
+++ b/examples/responsive-scaling.html
@@ -7,7 +7,7 @@
 		<script src="../compiled/flipclock.js"></script>		
 	</head>
 	<body>
-	<div class="clock" style="margin:8em; display: flex; align-items: center; justify-content: center;"></div>
+	<div class="clock" style="margin-top:8em; display: flex; align-items: center; justify-content: center;"></div>
 	<div class="message"></div>
 
 	<script type="text/javascript">

--- a/examples/responsive-scaling.html
+++ b/examples/responsive-scaling.html
@@ -17,7 +17,7 @@
 			
 			clock = $('.clock').FlipClock({
                 clockFace: 'MinuteCounter',
-                responsiveScaling: 3
+                responsiveScale: 3
 		    });
 		});
 	</script>

--- a/examples/responsive-scaling.html
+++ b/examples/responsive-scaling.html
@@ -7,7 +7,7 @@
 		<script src="../compiled/flipclock.js"></script>		
 	</head>
 	<body>
-	<div class="clock" style="margin:2em;"></div>
+	<div class="clock" style="margin:2em; margin-left:auto; margin-right:auto"></div>
 	<div class="message"></div>
 
 	<script type="text/javascript">
@@ -17,7 +17,7 @@
 			
 			clock = $('.clock').FlipClock({
                 clockFace: 'MinuteCounter',
-                responsiveScale: 3
+                responsiveScale: 2
 		    });
 		});
 	</script>

--- a/examples/responsive-scaling.html
+++ b/examples/responsive-scaling.html
@@ -7,7 +7,7 @@
 		<script src="../compiled/flipclock.js"></script>		
 	</head>
 	<body>
-	<div class="clock" style="margin:2em; margin-left:auto; margin-right:auto"></div>
+	<div class="clock" style="margin:8em; display: flex; align-items: center; justify-content: center;"></div>
 	<div class="message"></div>
 
 	<script type="text/javascript">

--- a/src/flipclock/js/libs/factory.js
+++ b/src/flipclock/js/libs/factory.js
@@ -81,6 +81,12 @@
 		 */	
 		 
 		countdown: false,
+		
+		/**
+		 * Scale the clock responsively. This value is the scale preffered on a screen 1920*1080. -1 to disable
+		 */
+
+		responsiveScale: -1,
 		 
 		/**
 		 * The name of the default clock face class to use if the defined
@@ -190,6 +196,8 @@
 			this.loadLanguage(this.language);
 			
 			this.loadClockFace(this.clockFace, options);
+			
+			this.setResponsiveScale();
 
 			if(this.autoStart) {
 				this.start();
@@ -373,6 +381,18 @@
 		 */
 		flip: function(doNotAddPlayClass) {	
 			this.face.flip(false, doNotAddPlayClass);
+		},
+		
+		/**
+		 * Sets the wrappers scaling responsively
+		 */
+		setResponsiveScale: function() {
+			if (this.responsiveScale != -1) {
+				var c = document.getElementsByClassName(this.classes.wrapper);
+				var perpx = this.responsiveScale / 1920;
+				var s = perpx * window.screen.width;
+				c[0].style.transform = "scale(" + s + ")";
+			}
 		}
 		
 	});


### PR DESCRIPTION
This adds the ability to scale the clock responsively.
In the clock init you can add `responsiveScale: scale` where scale is the amount of scaling you'd like on a 1920*1080 display. The default value is -1 which is disabled. 
It comes with an example, called responsive-scaling.html
